### PR TITLE
Fix and simplified publishing script

### DIFF
--- a/.github/workflows/github_publish.yml
+++ b/.github/workflows/github_publish.yml
@@ -24,6 +24,7 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.bintray_key }}
           PUBLISH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_USER_NAME: ${{ secrets.GITHUB_ACTOR }}
+          PUBLISH_VERSION_SUFFIX: ${{ secrets.PUBLISH_VERSION_SUFFIX }}
           PUBLISH_REPO_NAME: GithubMaven
           PUBLISH_URL: https://maven.pkg.github.com/tunjid/Android-Extensions
-        run: bash ./gradlew incrementalPublish -PpublishRepoName="$PUBLISH_REPO_NAME" -PpublishUrl="$PUBLISH_URL" -PpublishUserName="$PUBLISH_USER_NAME" -PpublishPassword="$PUBLISH_PASSWORD" -PbintrayUser="$BINTRAY_USER" -PbintrayApiKey="$BINTRAY_API_KEY" --stacktrace
+        run: bash ./gradlew incrementalPublish -Pversion_suffix="PUBLISH_VERSION_SUFFIX" -PpublishRepoName="$PUBLISH_REPO_NAME" -PpublishUrl="$PUBLISH_URL" -PpublishUserName="$PUBLISH_USER_NAME" -PpublishPassword="$PUBLISH_PASSWORD" -PbintrayUser="$BINTRAY_USER" -PbintrayApiKey="$BINTRAY_API_KEY" --stacktrace

--- a/README.md
+++ b/README.md
@@ -72,11 +72,24 @@ App icon made by [Freepik](https://www.freepik.com/?__hstc=57440181.7a5d7d3cc018
 
 ## Publishing
 
-Publishing is done with the `maven-publish` plugin. To publish a specific version of a module, run:
+Publishing is done with the `maven-publish` plugin.
 
-`./gradlew moduleName:assembleRelease`
-`./gradlew moduleName:publishLibPublicationTo*publishRepoName*Repository`
+To publish, run:
 
-By default, the `publishRepoName`, `publishUrl`, `publishUserName` and `publishPassword` are read from the `local.properties` file.
-They can however be overriden by passing gardle properties via the `-P` flag for each property you wish to override.
-Multi repository setup can only be done with the `local.properties file`.
+`./gradlew incrementalPublish`
+
+This will publish the latest version of every module, and will not override existing versions.
+The version of the module is determined by the version.properties file. To bump a module version, bump it in version.properties.
+
+By default, the `version_suffix`, `publishRepoName`, `publishUrl`, `publishUserName` and `publishPassword` are read from the `local.properties` file.
+They can however be overriden by passing gradle properties via the `-P` flag for each property you wish to override.
+
+A sample local.properties looks like:
+
+```
+version_suffix=mysuffix
+publishRepoName=MyMaven
+publishUrl=https://maven.pkg.github.com/myOrg/Android-Extensions
+publishUserName=mygithubusername
+publishPassword=mygithubtoken
+```

--- a/version.gradle
+++ b/version.gradle
@@ -1,7 +1,8 @@
 allprojects {
     def versionKey = project.name + "_version"
+    def versionSuffix = project.hasProperty('version_suffix') ? "-$version_suffix" : ""
     group = parent.ext.libProps['groupId']
-    version = parent.ext.libProps[versionKey]
+    version = parent.ext.libProps[versionKey] + versionSuffix
 
     task printProjectVersion {
         doLast {


### PR DESCRIPTION
@petergelsomino This fixes the weird publishing thing with dependencies getting mixed versions. After this, merging and pushing to master with a new version, should automatically publish the right version.