### PR TITLE
Sort stack fragments by priority

### DIFF
--- a/.github/workflows/navigation_tests.yml
+++ b/.github/workflows/navigation_tests.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Navigation test
-        uses: ReactiveCircus/android-emulator-runner@v2.6.2
+        uses: ReactiveCircus/android-emulator-runner@v2.13.0
         with:
           api-level: 21
           profile: pixel

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         tools:ignore="GoogleAppIndexingWarning">
         <activity
             android:name="com.tunjid.androidx.activities.MainActivity"
+            android:launchMode="singleTop"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/tunjid/androidx/activities/MainActivity.kt
+++ b/app/src/main/java/com/tunjid/androidx/activities/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.tunjid.androidx.activities
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
@@ -16,8 +17,8 @@ import com.tunjid.androidx.uidrivers.GlobalUiDriver
 import com.tunjid.androidx.uidrivers.GlobalUiHost
 import com.tunjid.androidx.uidrivers.materialDepthAxisTransition
 import com.tunjid.androidx.uidrivers.materialFadeThroughTransition
-import leakcanary.AppWatcher
 import java.util.concurrent.TimeUnit
+import leakcanary.AppWatcher
 
 class MainActivity : AppCompatActivity(), GlobalUiHost, Navigator.Controller {
 
@@ -27,9 +28,9 @@ class MainActivity : AppCompatActivity(), GlobalUiHost, Navigator.Controller {
     override val globalUiController by lazy { GlobalUiDriver(this, binding, navigator) }
 
     override val navigator: MultiStackNavigator by multiStackNavigationController(
-            tabs.size,
-            R.id.content_container,
-            RouteFragment.Companion::newInstance
+        tabs.size,
+        R.id.content_container,
+        RouteFragment.Companion::newInstance
     )
 
     public override fun onCreate(savedInstanceState: Bundle?) {
@@ -57,5 +58,12 @@ class MainActivity : AppCompatActivity(), GlobalUiHost, Navigator.Controller {
     override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
         R.id.menu_reset -> navigator.clearAll().let { true }
         else -> super.onOptionsItemSelected(item)
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        intent?.getIntExtra("nav", -1)
+            ?.takeIf { it >= 0 }
+            ?.let(navigator::show)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:2.0.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/build.gradle
+++ b/build.gradle
@@ -135,9 +135,8 @@ task incrementalPublish {
 
             return exists
         }
-        catch (e) {
-            println "Unable to configure incremental publish, check your internet connection"
-            e.printStackTrace()
+        catch (ignored) {
+            println "Unable to configure incremental publish for ${name}, check your internet connection"
             return null
         }
     }

--- a/navigation/src/main/java/com/tunjid/androidx/navigation/MultiStackNavigator.kt
+++ b/navigation/src/main/java/com/tunjid/androidx/navigation/MultiStackNavigator.kt
@@ -101,8 +101,7 @@ class MultiStackNavigator(
                 StackFragment::isAttached,
                 StackFragment::isResumed
             ))
-            .asReversed()
-            .first()
+            .last() // false come before true when comparing
 
     val activeIndex: Int
         get() = activeFragment.index

--- a/navigation/src/main/java/com/tunjid/androidx/navigation/MultiStackNavigator.kt
+++ b/navigation/src/main/java/com/tunjid/androidx/navigation/MultiStackNavigator.kt
@@ -87,17 +87,24 @@ class MultiStackNavigator(
     private val indices = 0 until stackCount
     internal val stackVisitor = MultiStackVisitor(stateContainer)
 
-    /**
-     * Mutable only because [clearAll]  replaces [StackFragment] instances. The alternative would
-     * be a computed property delegated to [FragmentManager.addedStackFragments], which has too
-     * many iterations in it's corresponding [FragmentManager.findFragmentByTag] to be justifiable.
-     */
-    internal var stackFragments: List<StackFragment>
+    internal val stackFragments: List<StackFragment>
+        get() = indices
+            .map(Int::toString)
+            .map(fragmentManager::findFragmentByTag)
+            .filterIsInstance<StackFragment>()
+            .filterNot(StackFragment::isRemoving)
 
     internal val activeFragment: StackFragment
-        get() = stackFragments.run { firstOrNull(Fragment::isAttached) ?: first() }
+        get() = stackFragments
+            .sortedWith(compareBy(
+                stackVisitor::isAt,
+                StackFragment::isAttached,
+                StackFragment::isResumed
+            ))
+            .asReversed()
+            .first()
 
-    val activeIndex
+    val activeIndex: Int
         get() = activeFragment.index
 
     val activeNavigator
@@ -108,10 +115,7 @@ class MultiStackNavigator(
 
     init {
         fragmentManager.registerFragmentLifecycleCallbacks(StackLifecycleCallback(), false)
-
         if (stateContainer.isFreshState) fragmentManager.commitNow { addStackFragments() }
-
-        stackFragments = fragmentManager.addedStackFragments(indices)
     }
 
     /**
@@ -134,7 +138,7 @@ class MultiStackNavigator(
      */
     fun clearAll() = reset(commitNow = true)
 
-    internal fun reset(commitNow: Boolean, onCommit: () -> Unit =  {}) =
+    internal fun reset(commitNow: Boolean, onCommit: () -> Unit = {}) =
         if (commitNow) fragmentManager.commitNow { reset(onCommit) }
         else fragmentManager.commit { reset(onCommit) }
 
@@ -142,15 +146,16 @@ class MultiStackNavigator(
         stackVisitor.leaveAll()
         stackFragments.forEach { remove(it) }
         addStackFragments()
-        runOnCommit { stackFragments = fragmentManager.addedStackFragments(indices); onCommit() }
+        runOnCommit { onCommit() }
     }
 
     override val previous: Fragment?
         get() = when (val peeked = activeNavigator.previous) {
             is Fragment -> peeked
-            else -> stackVisitor.previousHost()?.let {
-                stackFragments.elementAtOrNull(it)?.navigator?.current
-            }
+            else -> stackVisitor.previousHost()
+                ?.let(stackFragments::elementAtOrNull)
+                ?.navigator
+                ?.current
         }
 
     /**
@@ -161,7 +166,7 @@ class MultiStackNavigator(
      * @see [StackNavigator.pop]
      */
     override fun pop(): Boolean = when {
-        activeFragment.navigator.pop() ->
+        activeNavigator.pop() ->
             true
         stackVisitor.leave(activeFragment.index) ->
             showInternal(stackVisitor.currentHost(), false).let { true }
@@ -287,7 +292,4 @@ const val NAV_STACK_ORDER = "navState"
 
 private val Fragment.isAttached get() = !isDetached
 
-private fun FragmentManager.addedStackFragments(indices: IntRange) = indices
-    .map(Int::toString)
-    .map(::findFragmentByTag)
-    .filterIsInstance(StackFragment::class.java)
+private fun MultiStackVisitor.isAt(fragment: StackFragment) = fragment.index == currentHost()


### PR DESCRIPTION
@ghan0018 @stevepopovich 

The stacktrace for this crash is

```
  | at androidx.fragment.app.Fragment.getChildFragmentManager (Fragment.java:1)
-- | --
  | at com.tunjid.androidx.navigation.StackFragment$navigator$2.invoke (MultiStackNavigator.kt:235)
  | at com.tunjid.androidx.navigation.StackFragment$navigator$2.invoke (MultiStackNavigator.kt:235)
  | at kotlin.SynchronizedLazyImpl.getValue (LazyJVM.kt:6)
  | at com.tunjid.androidx.navigation.StackFragment.getNavigator$com_tunjid_androidx_navigation (Unknown Source:2)
  | at com.tunjid.androidx.navigation.MultiStackNavigator.getActiveNavigator (MultiStackNavigator.kt:104)
  | at com.tunjid.androidx.navigation.MultiStackNavigator.getCurrent (MultiStackNavigator.kt:107)
  | at com.gc.androdyssey.ui.home.UserHomeFragmentNavigator$6.invoke (UserHomeFragmentNavigator.kt:76)
  | at com.gc.androdyssey.ui.home.UserHomeFragmentNavigator$6.invoke (UserHomeFragmentNavigator.kt:76)
  | at com.tunjid.androidx.navigation.StackNavigator.push (StackNavigator.kt:95)
  | at com.tunjid.androidx.navigation.Navigator$DefaultImpls.push (Navigator.kt:85)
  | at com.tunjid.androidx.navigation.StackNavigator.access$auditFragment (StackNavigator.kt:32)
  | at com.tunjid.androidx.navigation.MultiStackNavigator.showRoot (MultiStackNavigator.kt:210)
  | at com.tunjid.androidx.navigation.MultiStackNavigator.access$getIndices$p (MultiStackNavigator.kt:56)
  | at com.tunjid.androidx.navigation.MultiStackNavigator$StackLifecycleCallback.onFragmentResumed (MultiStackNavigator.kt:228)
  | at androidx.fragment.app.FragmentLifecycleCallbacksDispatcher.dispatchOnFragmentResumed (FragmentLifecycleCallbacksDispatcher.java:208)
  | at androidx.fragment.app.FragmentStateManager.resume (FragmentStateManager.java:612)
  | at androidx.fragment.app.FragmentStateManager.moveToExpectedState (FragmentStateManager.java:277)
  | at androidx.fragment.app.SpecialEffectsController$FragmentStateManagerOperation.complete (SpecialEffectsController.java:722)
  | at androidx.fragment.app.SpecialEffectsController$Operation.completeSpecialEffect (SpecialEffectsController.java:657)
  | at androidx.fragment.app.DefaultSpecialEffectsController$SpecialEffectsInfo.completeSpecialEffect (DefaultSpecialEffectsController.java:739)
  | at androidx.fragment.app.DefaultSpecialEffectsController.startAnimations (DefaultSpecialEffectsController.java:145)
  | at androidx.fragment.app.DefaultSpecialEffectsController.executeOperations (DefaultSpecialEffectsController.java:115)
  | at androidx.fragment.app.SpecialEffectsController.executePendingOperations (SpecialEffectsController.java:285)
  | at androidx.fragment.app.FragmentManager.executeOpsTogether (FragmentManager.java:2177)
  | at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute (FragmentManager.java:2088)
  | at androidx.fragment.app.FragmentManager.execPendingActions (FragmentManager.java:1990)
  | at androidx.fragment.app.FragmentManager$5.run (FragmentManager.java:524)
  | at android.os.Handler.handleCallback (Handler.java:883)
  | at android.os.Handler.dispatchMessage (Handler.java:100)
  | at android.os.Looper.loop (Looper.java:237)
  | at android.app.ActivityThread.main (ActivityThread.java:7860)
  | at java.lang.reflect.Method.invoke (Native Method)
  | at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
  | at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1075)
```

Which if you follow, is when the user navigates away from a tab, the `activeFragment` method returns the first `StackFragment` that is attached. Now only 1 `StackFragment` should be attached at any one time, but after process death, all may be. before their states are restored. 

This PR makes it that we bias the selection of the current `Fragment` with the following:

```kotlin
    internal val activeFragment: StackFragment
        get() = stackFragments
            .sortedWith(compareBy(
                stackVisitor::isAt,
                StackFragment::isAttached,
                StackFragment::isResumed
            ))
            .last()
```

So now even if multiple `StackFragments` are attached,  our selection is biased towards the last visited tab, and if it is resumed.

[ch160320]
