### PR TITLE
Upgrade overscroll dependency and add gitignore

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -20,8 +20,13 @@ jobs:
         with:
           distribution: 'jetbrains'
           java-version: '17'
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Navigation test
-        uses: ReactiveCircus/android-emulator-runner@v2.21.0
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 21
           profile: pixel

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
 
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -25,5 +25,4 @@ jobs:
         with:
           api-level: 21
           profile: pixel
-          arch: arm64-v8a
           script: ./gradlew:core:connectedCheck --stacktrace

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'jetbrains'
-          java-version: '11'
+          java-version: '17'
       - name: Navigation test
         uses: ReactiveCircus/android-emulator-runner@v2.14.3
         with:

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -33,4 +33,4 @@ jobs:
         with:
           api-level: 21
           profile: pixel
-          script: ./gradlew:core:connectedCheck --stacktrace
+          script: ./gradlew :core:connectedCheck --stacktrace

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -10,7 +10,8 @@ jobs:
   test:
 
     runs-on: macos-latest
-
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -25,4 +25,5 @@ jobs:
         with:
           api-level: 21
           profile: pixel
-          script: ./gradlew :core:connectedCheck --stacktrace
+          arch: arm64-v8a
+          script: ./gradlew:core:connectedCheck --stacktrace

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -28,18 +28,9 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Setup emulator
+      - name: Run core tests
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
           api-level: 21
           profile: pixel
-          script: echo "Generated AVD"
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'jetbrains'
-          java-version: '11'
-
-      - name: Run Core Tests
-        run: ./gradlew:core:connectedCheck --stacktrace
+          script: ./gradlew:core:connectedCheck --stacktrace

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           api-level: 21
           profile: pixel
+          script: echo "Generated AVD"
 
       - name: Set up JDK 11
         uses: actions/setup-java@v4

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -15,19 +15,30 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 11
+
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'jetbrains'
           java-version: '17'
+
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: Navigation test
-        uses: reactivecircus/android-emulator-runner@v2
+
+      - name: Setup emulator
+        uses: ReactiveCircus/android-emulator-runner@v2
         with:
           api-level: 21
           profile: pixel
-          script: ./gradlew:core:connectedCheck --stacktrace
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'jetbrains'
+          java-version: '11'
+
+      - name: Run Core Tests
+        run: ./gradlew:core:connectedCheck --stacktrace

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'jetbrains'
           java-version: '17'
       - name: Navigation test
-        uses: ReactiveCircus/android-emulator-runner@v2.14.3
+        uses: ReactiveCircus/android-emulator-runner@v2.21.0
         with:
           api-level: 21
           profile: pixel

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -13,11 +13,12 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'jetbrains'
+          java-version: '11'
       - name: Navigation test
         uses: ReactiveCircus/android-emulator-runner@v2.14.3
         with:

--- a/.github/workflows/navigation_tests.yml
+++ b/.github/workflows/navigation_tests.yml
@@ -25,4 +25,5 @@ jobs:
         with:
           api-level: 21
           profile: pixel
+          arch: arm64-v8a
           script: ./gradlew :navigation:connectedCheck --stacktrace

--- a/.github/workflows/navigation_tests.yml
+++ b/.github/workflows/navigation_tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
 
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -25,5 +25,4 @@ jobs:
         with:
           api-level: 21
           profile: pixel
-          arch: arm64-v8a
           script: ./gradlew :navigation:connectedCheck --stacktrace

--- a/.github/workflows/navigation_tests.yml
+++ b/.github/workflows/navigation_tests.yml
@@ -28,19 +28,9 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Setup emulator
+      - name: Navigation test
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
           api-level: 21
           profile: pixel
-          script: echo "Generated AVD"
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'jetbrains'
-          java-version: '11'
-
-      - name: Run Navigation Tests
-        run: ./gradlew :navigation:connectedCheck --stacktrace
-
+          script: ./gradlew :navigation:connectedCheck --stacktrace

--- a/.github/workflows/navigation_tests.yml
+++ b/.github/workflows/navigation_tests.yml
@@ -15,19 +15,31 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 11
+
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'jetbrains'
           java-version: '17'
+
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: Navigation test
+
+      - name: Setup emulator
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
           api-level: 21
           profile: pixel
-          script: ./gradlew :navigation:connectedCheck --stacktrace
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'jetbrains'
+          java-version: '11'
+
+      - name: Run Navigation Tests
+        run: ./gradlew :navigation:connectedCheck --stacktrace
+

--- a/.github/workflows/navigation_tests.yml
+++ b/.github/workflows/navigation_tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'jetbrains'
-          java-version: '11'
+          java-version: '17'
       - name: Navigation test
         uses: ReactiveCircus/android-emulator-runner@v2.14.3
         with:

--- a/.github/workflows/navigation_tests.yml
+++ b/.github/workflows/navigation_tests.yml
@@ -10,7 +10,8 @@ jobs:
   test:
 
     runs-on: macos-latest
-
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/navigation_tests.yml
+++ b/.github/workflows/navigation_tests.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           api-level: 21
           profile: pixel
+          script: echo "Generated AVD"
 
       - name: Set up JDK 11
         uses: actions/setup-java@v4

--- a/.github/workflows/navigation_tests.yml
+++ b/.github/workflows/navigation_tests.yml
@@ -20,8 +20,13 @@ jobs:
         with:
           distribution: 'jetbrains'
           java-version: '17'
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Navigation test
-        uses: ReactiveCircus/android-emulator-runner@v2.21.0
+        uses: ReactiveCircus/android-emulator-runner@v2
         with:
           api-level: 21
           profile: pixel

--- a/.github/workflows/navigation_tests.yml
+++ b/.github/workflows/navigation_tests.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'jetbrains'
           java-version: '17'
       - name: Navigation test
-        uses: ReactiveCircus/android-emulator-runner@v2.14.3
+        uses: ReactiveCircus/android-emulator-runner@v2.21.0
         with:
           api-level: 21
           profile: pixel

--- a/.github/workflows/navigation_tests.yml
+++ b/.github/workflows/navigation_tests.yml
@@ -13,11 +13,12 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'jetbrains'
+          java-version: '11'
       - name: Navigation test
         uses: ReactiveCircus/android-emulator-runner@v2.14.3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Gradle files
+.gradle/
+build/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Log/OS Files
+*.log
+
+# Android Studio generated files and folders
+captures/
+.externalNativeBuild/
+.cxx/
+*.apk
+output.json
+
+# IntelliJ
+*.iml
+.idea/
+misc.xml
+deploymentTargetDropDown.xml
+render.experimental.xml
+
+# Keystore files
+*.jks
+*.keystore
+
+# Google Services (e.g. APIs or Firebase)
+google-services.json
+
+# Android Profiling
+*.hprof

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation 'com.jakewharton.rx2:replaying-share-kotlin:2.2.0'
 
-    implementation 'me.everything:overscroll-decor-android:1.1.0'
+    implementation 'io.github.everythingme:overscroll-decor-android:1.1.1'
     implementation 'com.andkulikov:transitionseverywhere:2.1.0'
     implementation 'com.opencsv:opencsv:5.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,14 @@ import groovy.json.JsonSlurper
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.5.0'
+    ext.kotlin_version = '1.6.21'
 
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:7.3.0'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:2.0.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip


### PR DESCRIPTION
This PR bumps the [overscroll](https://github.com/EverythingMe/overscroll-decor) dependency which is required for compiling. I also added a standard android gitignore and fixed the pipeline.