### PR TITLE
Add option to prevent saved state crashes

### DIFF
--- a/app/src/main/java/com/tunjid/androidx/MainActivity.kt
+++ b/app/src/main/java/com/tunjid/androidx/MainActivity.kt
@@ -35,6 +35,7 @@ class MainActivity : AppCompatActivity(), GlobalUiHost, Navigator.Controller {
         stackCount = tabs.size,
         containerId = R.id.content_container,
         backStackType = MultiStackNavigator.BackStackType.Unlimited,
+        stopInvalidNavigation = true,
         rootFunction = RouteFragment.Companion::newInstance,
     )
 

--- a/app/src/main/java/com/tunjid/androidx/tabnav/navigator/IndependentStacksFragment.kt
+++ b/app/src/main/java/com/tunjid/androidx/tabnav/navigator/IndependentStacksFragment.kt
@@ -102,6 +102,7 @@ class IndependentStacksFragment : Fragment(R.layout.fragment_independent_stack) 
     private fun navigatorFor(id: Int) = navigators.getOrPut(id) {
         val stackNavigator by childStackNavigationController(
             containerId = id,
+            stopInvalidNavigation = true
         )
         stackNavigator.apply { transactionModifier = { crossFade() } }
     }

--- a/app/src/main/java/com/tunjid/androidx/tabnav/navigator/MultipleStacksFragment.kt
+++ b/app/src/main/java/com/tunjid/androidx/tabnav/navigator/MultipleStacksFragment.kt
@@ -56,6 +56,7 @@ class MultipleStacksFragment : Fragment(R.layout.fragment_multiple_stack) {
     internal val innerNavigator: MultiStackNavigator by childMultiStackNavigationController(
         stackCount = DESTINATIONS.size,
         containerId = R.id.inner_container,
+        stopInvalidNavigation = true,
         rootFunction = { index ->
             MultipleStackChildFragment.newInstance(getChildName(index), 1)
         }

--- a/navigation/src/androidTest/java/com/tunjid/androidx/navigation/MultiStackNavigatorTest.kt
+++ b/navigation/src/androidTest/java/com/tunjid/androidx/navigation/MultiStackNavigatorTest.kt
@@ -337,7 +337,8 @@ class MultiStackNavigatorTest {
                 stateContainer = savedStateFor(activity, "test"),
                 fragmentManager = activity.supportFragmentManager,
                 backStackType = type,
-                containerId = activity.containerId
+                containerId = activity.containerId,
+                stopInvalidNavigation = true,
             ) { NavigationTestFragment.newInstance(TAGS[it]) }
         }
 

--- a/navigation/src/androidTest/java/com/tunjid/androidx/navigation/StackNavigatorTest.kt
+++ b/navigation/src/androidTest/java/com/tunjid/androidx/navigation/StackNavigatorTest.kt
@@ -48,7 +48,11 @@ class StackNavigatorTest {
     @Before
     fun setUp() {
         activity = activityRule.activity as NavigationTestActivity
-        stackNavigator = StackNavigator(activity.supportFragmentManager, activity.containerId)
+        stackNavigator = StackNavigator(
+            fragmentManager = activity.supportFragmentManager,
+            containerId = activity.containerId,
+            stopInvalidNavigation = true
+        )
     }
 
     @After
@@ -74,7 +78,11 @@ class StackNavigatorTest {
 
         // create new instance of StackNavigator and confirm all
         // the old tags are restored
-        val copy = StackNavigator(activity.supportFragmentManager, activity.containerId)
+        val copy = StackNavigator(
+            fragmentManager = activity.supportFragmentManager,
+            containerId = activity.containerId,
+            stopInvalidNavigation = true
+        )
 
         assertTrue(copy.fragmentTags.contains(testFragment.stableTag))
         assertTrue(copy.fragmentTags.size == 1)

--- a/navigation/src/main/java/com/tunjid/androidx/navigation/MultiStackNavigator.kt
+++ b/navigation/src/main/java/com/tunjid/androidx/navigation/MultiStackNavigator.kt
@@ -1,6 +1,7 @@
 package com.tunjid.androidx.navigation
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -26,7 +27,8 @@ fun Fragment.childMultiStackNavigationController(
     stackCount: Int,
     @IdRes containerId: Int,
     backStackType: MultiStackNavigator.BackStackType = MultiStackNavigator.BackStackType.UniqueEntries,
-    rootFunction: (Int) -> Fragment
+    stopInvalidNavigation: Boolean,
+    rootFunction: (Int) -> Fragment,
 ): Lazy<MultiStackNavigator> = lazy {
     MultiStackNavigator(
         stackCount = stackCount,
@@ -34,7 +36,8 @@ fun Fragment.childMultiStackNavigationController(
         fragmentManager = childFragmentManager,
         containerId = containerId,
         backStackType = backStackType,
-        rootFunction = rootFunction
+        rootFunction = rootFunction,
+        stopInvalidNavigation = stopInvalidNavigation
     )
 }
 
@@ -42,7 +45,8 @@ fun FragmentActivity.multiStackNavigationController(
     stackCount: Int,
     @IdRes containerId: Int,
     backStackType: MultiStackNavigator.BackStackType = MultiStackNavigator.BackStackType.UniqueEntries,
-    rootFunction: (Int) -> Fragment
+    stopInvalidNavigation: Boolean,
+    rootFunction: (Int) -> Fragment,
 ): Lazy<MultiStackNavigator> = lazy {
     MultiStackNavigator(
         stackCount = stackCount,
@@ -50,7 +54,8 @@ fun FragmentActivity.multiStackNavigationController(
         fragmentManager = supportFragmentManager,
         containerId = containerId,
         backStackType = backStackType,
-        rootFunction = rootFunction
+        rootFunction = rootFunction,
+        stopInvalidNavigation = stopInvalidNavigation
     )
 }
 
@@ -64,7 +69,9 @@ class MultiStackNavigator(
     private val fragmentManager: FragmentManager,
     @IdRes override val containerId: Int,
     backStackType: BackStackType = BackStackType.UniqueEntries,
-    private val rootFunction: (Int) -> Fragment) : Navigator {
+    private val stopInvalidNavigation: Boolean,
+    private val rootFunction: (Int) -> Fragment,
+) : Navigator {
 
     /**
      * A callback that will be invoked when a stack is selected, either by the user selecting it,
@@ -213,7 +220,14 @@ class MultiStackNavigator(
     private fun FragmentTransaction.addStackFragments() {
         indices.forEach { index ->
             stackTransactionModifier?.invoke(this, index)
-            add(containerId, StackFragment.newInstance(index), index.toString())
+            add(
+                containerId,
+                StackFragment.newInstance(
+                    index = index,
+                    stopInvalidNavigation = stopInvalidNavigation
+                ),
+                index.toString()
+            )
         }
     }
 
@@ -224,6 +238,11 @@ class MultiStackNavigator(
         override fun onFragmentCreated(fm: FragmentManager, fragment: Fragment, savedInstanceState: Bundle?) = fragment.run {
             if (id != this@MultiStackNavigator.containerId) return
             check(this is StackFragment) { "Only Stack Fragments may be added to a container View managed by a MultiStackNavigator" }
+
+            if (stopInvalidNavigation && fm.isStateSaved) {
+                Log.i("StackNavigator", "Ignoring push call in onFragmentCreated, FragmentManager is in an invalid state")
+                return
+            }
 
             if (index != stackVisitor.currentHost() && isAttached) fm.commit { detach(this@run) }
         }
@@ -252,15 +271,30 @@ class StackFragment : Fragment() {
 
     internal var index: Int by fragmentArgs()
     private var containerId: Int by fragmentArgs()
+    private var stopInvalidNavigation: Boolean by fragmentArgs()
 
     internal val hasNoRoot get() = navigator.current == null
-    internal val navigator by lazy { StackNavigator(childFragmentManager, containerId) }
+    internal val navigator by lazy {
+        StackNavigator(
+            fragmentManager = childFragmentManager,
+            containerId = containerId,
+            stopInvalidNavigation = stopInvalidNavigation,
+        )
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
         FragmentContainerView(inflater.context).apply { id = containerId }
 
     companion object {
-        internal fun newInstance(index: Int) = StackFragment().apply { this.index = index; containerId = View.generateViewId() }
+        internal fun newInstance(
+            index: Int,
+            stopInvalidNavigation: Boolean
+        ) =
+            StackFragment().apply {
+                this.index = index
+                this.stopInvalidNavigation = stopInvalidNavigation
+                containerId = View.generateViewId()
+            }
     }
 }
 

--- a/navigation/src/main/java/com/tunjid/androidx/navigation/StackNavigator.kt
+++ b/navigation/src/main/java/com/tunjid/androidx/navigation/StackNavigator.kt
@@ -12,13 +12,27 @@ import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-fun Fragment.childStackNavigationController(@IdRes containerId: Int): Lazy<StackNavigator> = lazy {
-    StackNavigator(childFragmentManager, containerId)
+fun Fragment.childStackNavigationController(
+    @IdRes containerId: Int,
+    stopInvalidNavigation: Boolean
+): Lazy<StackNavigator> = lazy {
+    StackNavigator(
+        fragmentManager = childFragmentManager,
+        containerId = containerId,
+        stopInvalidNavigation = stopInvalidNavigation
+    )
 }
 
 @Suppress("unused")
-fun FragmentActivity.stackNavigationController(@IdRes containerId: Int): Lazy<StackNavigator> = lazy {
-    StackNavigator(supportFragmentManager, containerId)
+fun FragmentActivity.stackNavigationController(
+    @IdRes containerId: Int,
+    stopInvalidNavigation: Boolean
+): Lazy<StackNavigator> = lazy {
+    StackNavigator(
+        fragmentManager = supportFragmentManager,
+        containerId = containerId,
+        stopInvalidNavigation = stopInvalidNavigation
+    )
 }
 
 /**
@@ -33,7 +47,8 @@ fun FragmentActivity.stackNavigationController(@IdRes containerId: Int): Lazy<St
 
 class StackNavigator constructor(
     internal val fragmentManager: FragmentManager,
-    @param:IdRes @field:IdRes @get:IdRes override val containerId: Int
+    @param:IdRes @field:IdRes @get:IdRes override val containerId: Int,
+    private val stopInvalidNavigation: Boolean,
 ) : Navigator {
 
     /**
@@ -92,6 +107,11 @@ class StackNavigator constructor(
         val fragmentToShow =
             (if (fragmentAlreadyExists) fragmentManager.findFragmentByTag(tag)
             else fragment) ?: throw NullPointerException(MSG_DODGY_FRAGMENT)
+
+        if (stopInvalidNavigation && fragmentManager.isStateSaved) {
+            Log.i("StackNavigator", "Ignoring push call, FragmentManager is in an invalid state")
+            return fragmentShown
+        }
 
         fragmentManager.commit {
             transactionModifier?.invoke(this, fragment)


### PR DESCRIPTION
This PR adds the option to suppress navigation events that happen because the fragment manager is in a saved state. This only happens when the activity has been destroyed and re-created.

I took this approach since in some cases, the app is in the background when it crashes. It also doesn't seem to mess with navigation that I can tell. It's a toggle so we can feature tag it!

Also, this is what the Android [FragmentNavigator](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:navigation/navigation-fragment/src/main/java/androidx/navigation/fragment/FragmentNavigator.kt;l=399?q=fragmentnav&ss=androidx%2Fplatform%2Fframeworks%2Fsupport) checks for as well!

### Before

https://github.com/user-attachments/assets/c8c2f7b6-b12c-4c43-9a33-6ad46eec698f

### After

https://github.com/user-attachments/assets/91517a00-49ae-494f-aaca-34506392039c

